### PR TITLE
Update webpack.base.config.js

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -17,12 +17,12 @@ module.exports = {
     rules: [
       {
         test: /\.vue$/,
-        loader: 'vue',
+        loader: 'vue-loader',
         options: vueConfig
       },
       {
         test: /\.js$/,
-        loader: 'babel',
+        loader: 'babel-loader',
         exclude: /node_modules/
       },
       {


### PR DESCRIPTION
遇到如下错误
```
Entry module not found: Error: Can't resolve 'babel' in 'v2ex_frontend-master'
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
```

and
```
[Vue warn]: Vue is a constructor and should be called with the `new` keyword
./src/components/App.vue
Module build failed: TypeError: this._init is not a function
```
所以 webpack 里的相关配置要更新一下了